### PR TITLE
fix 2 issues

### DIFF
--- a/src/mame2003/mame2003.c
+++ b/src/mame2003/mame2003.c
@@ -789,7 +789,7 @@ bool retro_load_game(const struct retro_game_info *game)
     }
 	if(driverIndex == total_drivers -2) // we could fix the total drives in drivers c but the it pointless its taken into account here
 	{
-      log_cb(RETRO_LOG_ERROR, LOGPRE "Driver index counter: %d. Game driver not found for %s!\n", driverIndex, needle->name);
+      log_cb(RETRO_LOG_ERROR, LOGPRE "Driver index counter: %d. Game driver not found for %s!\n", driverIndex, driver_lookup);
       return false;
 	}
  }

--- a/src/vidhrdw/beathead_vidhrdw.c
+++ b/src/vidhrdw/beathead_vidhrdw.c
@@ -225,9 +225,13 @@ VIDEO_UPDATE( beathead )
 		UINT8 scanline[336];
 
 		/* unswizzle the scanline first */
-		for (x = cliprect->min_x; x <= cliprect->max_x; x++)
-			scanline[x] = ((data8_t *)videoram32)[BYTE4_XOR_LE(src++)];
-
+		if (scanline_offset[y] != ~0)
+		{
+			for (x = cliprect->min_x; x <= cliprect->max_x; x++)
+				scanline[x] = ((UINT8 *)videoram32)[BYTE4_XOR_LE(src++)];
+		}
+		else
+			memset(scanline, 0, sizeof(scanline));
 		/* then draw it */
 		draw_scanline8(bitmap, cliprect->min_x, y, cliprect->max_x - cliprect->min_x + 1, &scanline[cliprect->min_x], &Machine->pens[scanline_palette[y] * 256], -1);
 	}


### PR DESCRIPTION
https://github.com/libretro/mame2003-plus-libretro/issues/721

https://github.com/libretro/mame2003-plus-libretro/issues/710

This fixed the cosmetic part of not showing the right driver name when a rom doesnt exist. Without any logs i cant really see whats going on with the 3ds. 

It has to be something to do with the content path retroarch is returning. I cant do pull request on the main repo or comment so there really isisnt much i can do from here will need to ask the libretro team for more support on this. I dont mind helping with driver issues ect anything libretro will have to be fixed by there own support system if they even have one. 

the only suggestion I could give you is to update libretro common
